### PR TITLE
URL encoding done with urllib.parse.quote

### DIFF
--- a/mirror/__init__.py
+++ b/mirror/__init__.py
@@ -7,7 +7,7 @@ __description__ = "Tools for software project analysis"
 
 __email__ = "engineering@bugout.dev"
 __license__ = "MIT"
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 __all__ = (
     "__author__",

--- a/mirror/github/search.py
+++ b/mirror/github/search.py
@@ -47,8 +47,8 @@ def request_with_limit(url, headers, min_rate_limit):
 
 
 def encode_query(stars_expression, language):
-    stars_encoding = str(urllib.parse.unquote_plus(f"stars:{stars_expression}"))
-    lang_encoding = str(urllib.parse.unquote_plus(f"language:{language.capitalize()}"))
+    stars_encoding = str(urllib.parse.quote(f"stars:{stars_expression}"))
+    lang_encoding = str(urllib.parse.quote(f"language:{language.capitalize()}"))
     return f"{stars_encoding}+{lang_encoding}"
 
 


### PR DESCRIPTION
We were using unquote_plus before.